### PR TITLE
Add industry configuration structure

### DIFF
--- a/includes/industry-configs/class-creative-config.php
+++ b/includes/industry-configs/class-creative-config.php
@@ -1,0 +1,11 @@
+<?php
+class WSM_Creative_Config extends WSM_Industry_Config {
+    protected $labels = [
+        'participant' => 'Artist',
+        'session' => 'Workshop',
+        'instructor' => 'Instructor'
+    ];
+    protected $features = ['portfolio', 'supply_lists', 'project_gallery'];
+    protected $required_fields = ['experience_level', 'materials_owned'];
+    protected $integrations = ['portfolio_sites', 'social_sharing'];
+}

--- a/includes/industry-configs/class-education-config.php
+++ b/includes/industry-configs/class-education-config.php
@@ -1,0 +1,11 @@
+<?php
+class WSM_Education_Config extends WSM_Industry_Config {
+    protected $labels = [
+        'participant' => 'Student',
+        'session' => 'Lesson',
+        'instructor' => 'Teacher'
+    ];
+    protected $features = ['progress_tracking', 'assignments', 'recitals'];
+    protected $required_fields = ['skill_level', 'instrument', 'parent_contact'];
+    protected $integrations = ['practice_tracking', 'sheet_music'];
+}

--- a/includes/industry-configs/class-fitness-config.php
+++ b/includes/industry-configs/class-fitness-config.php
@@ -1,0 +1,11 @@
+<?php
+class WSM_Fitness_Config extends WSM_Industry_Config {
+    protected $labels = [
+        'participant' => 'Member',
+        'session' => 'Class',
+        'instructor' => 'Trainer'
+    ];
+    protected $features = ['body_composition', 'progress_photos', 'workout_plans'];
+    protected $required_fields = ['emergency_contact', 'health_conditions'];
+    protected $integrations = ['heart_rate_monitors', 'nutrition_tracking'];
+}

--- a/includes/industry-configs/class-industry-config-interface.php
+++ b/includes/industry-configs/class-industry-config-interface.php
@@ -1,0 +1,7 @@
+<?php
+interface WSM_Industry_Config_Interface {
+    public function get_labels();
+    public function get_features();
+    public function get_required_fields();
+    public function get_integrations();
+}

--- a/includes/industry-configs/class-industry-config.php
+++ b/includes/industry-configs/class-industry-config.php
@@ -1,0 +1,23 @@
+<?php
+abstract class WSM_Industry_Config implements WSM_Industry_Config_Interface {
+    protected $labels = [];
+    protected $features = [];
+    protected $required_fields = [];
+    protected $integrations = [];
+
+    public function get_labels() {
+        return $this->labels;
+    }
+
+    public function get_features() {
+        return $this->features;
+    }
+
+    public function get_required_fields() {
+        return $this->required_fields;
+    }
+
+    public function get_integrations() {
+        return $this->integrations;
+    }
+}

--- a/includes/industry-configs/class-sports-config.php
+++ b/includes/industry-configs/class-sports-config.php
@@ -1,0 +1,11 @@
+<?php
+class WSM_Sports_Config extends WSM_Industry_Config {
+    protected $labels = [
+        'participant' => 'Athlete',
+        'session' => 'Class',
+        'instructor' => 'Coach'
+    ];
+    protected $features = [];
+    protected $required_fields = [];
+    protected $integrations = [];
+}

--- a/includes/industry-configs/class-wellness-config.php
+++ b/includes/industry-configs/class-wellness-config.php
@@ -1,0 +1,11 @@
+<?php
+class WSM_Wellness_Config extends WSM_Industry_Config {
+    protected $labels = [
+        'participant' => 'Client',
+        'session' => 'Session',
+        'instructor' => 'Therapist'
+    ];
+    protected $features = [];
+    protected $required_fields = [];
+    protected $integrations = [];
+}

--- a/includes/industry-configs/index.php
+++ b/includes/industry-configs/index.php
@@ -1,2 +1,9 @@
 <?php
-// Silence is golden.
+// Industry config loader
+require_once __DIR__ . '/class-industry-config-interface.php';
+require_once __DIR__ . '/class-industry-config.php';
+require_once __DIR__ . '/class-fitness-config.php';
+require_once __DIR__ . '/class-education-config.php';
+require_once __DIR__ . '/class-creative-config.php';
+require_once __DIR__ . '/class-sports-config.php';
+require_once __DIR__ . '/class-wellness-config.php';

--- a/wp-studio-manager.php
+++ b/wp-studio-manager.php
@@ -12,6 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+require_once plugin_dir_path( __FILE__ ) . 'includes/industry-configs/index.php';
+
 if ( ! class_exists( 'WP_Studio_Manager' ) ) :
 final class WP_Studio_Manager {
 
@@ -643,27 +645,25 @@ final class WP_Studio_Manager {
 
     public static function get_labels() {
         $industry = get_option( 'wsm_industry', 'sports' );
-        $defaults = array(
-            'sports' => array(
-                'client' => __( 'Athlete', 'wsm' ),
-                'staff'  => __( 'Coach', 'wsm' ),
-                'class'  => __( 'Class', 'wsm' ),
-                'level'  => __( 'Level', 'wsm' ),
-            ),
-            'education' => array(
-                'client' => __( 'Student', 'wsm' ),
-                'staff'  => __( 'Instructor', 'wsm' ),
-                'class'  => __( 'Period', 'wsm' ),
-                'level'  => __( 'Grade', 'wsm' ),
-            ),
-            'fitness' => array(
-                'client' => __( 'Client', 'wsm' ),
-                'staff'  => __( 'Trainer', 'wsm' ),
-                'class'  => __( 'Class', 'wsm' ),
-                'level'  => __( 'Level', 'wsm' ),
-            ),
-        );
-        return isset( $defaults[ $industry ] ) ? $defaults[ $industry ] : $defaults['sports'];
+        switch ( $industry ) {
+            case 'fitness':
+                $config = new WSM_Fitness_Config();
+                break;
+            case 'education':
+                $config = new WSM_Education_Config();
+                break;
+            case 'creative':
+                $config = new WSM_Creative_Config();
+                break;
+            case 'wellness':
+                $config = new WSM_Wellness_Config();
+                break;
+            case 'sports':
+            default:
+                $config = new WSM_Sports_Config();
+                break;
+        }
+        return $config->get_labels();
     }
 }
 endif;


### PR DESCRIPTION
## Summary
- implement configurable industry classes for sports, fitness, education, creative, and wellness
- load configuration system in main plugin file
- provide dynamic label lookup using selected industry

## Testing
- `php -l wp-studio-manager.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6854d187852c8321bf28c72c042e3c9b